### PR TITLE
attack indicator should match hitbox

### DIFF
--- a/Assets/Prefabs/Player Bot.prefab
+++ b/Assets/Prefabs/Player Bot.prefab
@@ -372,7 +372,6 @@ Transform:
   - {fileID: 6711962913893494177}
   - {fileID: 553778726335854191}
   - {fileID: 6140331725892527333}
-  - {fileID: 1209418372181982417}
   - {fileID: 3536109963626013121}
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -402,26 +401,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rigidbody: {fileID: 0}
-  attackPoint: {fileID: 1209418372181982417}
-  attackRange: {x: 5, y: 0.1, z: 5}
-  attackIndicator: {fileID: 5440464042939631149}
+  attackObject: {fileID: 5440464042939631149}
   enemyLayers:
     serializedVersion: 2
     m_Bits: 64
   upChargeConsumption: 1
-  upThreshold: 0
-  upCooldown: 0.25
+  upCooldown: 0.5
   downChargeConsumption: 1.5
-  downThreshold: 1
   downCooldown: 2
   downMine: {fileID: 4340560450993231603, guid: 1be873c2652df45259d02c6db7b3942b, type: 3}
   leftChargeConsumption: 1
-  leftThreshold: 0
   leftCooldown: 0.25
-  dashCooldown: 1
   dashLength: 0.25
   rightChargeConsumption: 1
-  rightThreshold: 0
   rightCooldown: 0.25
   knockbackRadius: 1000
   knockbackPower: 10
@@ -776,8 +768,9 @@ GameObject:
   - component: {fileID: 1451455150531847363}
   - component: {fileID: 5270083097620861867}
   - component: {fileID: 736633869646187426}
+  - component: {fileID: 7262383754503954780}
   m_Layer: 0
-  m_Name: Cube
+  m_Name: AttackObject
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -795,7 +788,7 @@ Transform:
   m_LocalScale: {x: 0.5, y: 0.0030000003, z: 0.5}
   m_Children: []
   m_Father: {fileID: 2423140888823559235}
-  m_RootOrder: 14
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1451455150531847363
 MeshFilter:
@@ -859,6 +852,21 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0.00000023841858, y: 0.00000023841858, z: 0.00000023841858}
+--- !u!114 &7262383754503954780
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5440464042939631149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72493c55c012e4370b2d2c21db5fde4c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  enemyLayers:
+    serializedVersion: 2
+    m_Bits: 64
 --- !u!1 &7028195527748912881
 GameObject:
   m_ObjectHideFlags: 0
@@ -1426,33 +1434,3 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!1 &8932697823666684511
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1209418372181982417}
-  m_Layer: 0
-  m_Name: AttackPoint
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1209418372181982417
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8932697823666684511}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.0039, y: 0.08570019, z: 0.074}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 2423140888823559235}
-  m_RootOrder: 13
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/Player/PlayerCombat.cs
+++ b/Assets/Scripts/Player/PlayerCombat.cs
@@ -11,10 +11,8 @@ public class PlayerCombat : MonoBehaviour
     public Rigidbody rigidbody;
     private PlayerAudio _playerAudio;
     
-    public Transform attackPoint;
-    public Vector3 attackRange = new Vector3(0.5f, 0.5f, 0.25f);
-    //cube is just a visual for now, once animation is added can be removed
-    public GameObject attackIndicator;
+    //update, cube is the hit box and the indicator, but only attacks on frame 1 of appearing
+    public GameObject attackObject;
     public LayerMask enemyLayers;
 
     public float upChargeConsumption = 0.3f;
@@ -103,8 +101,10 @@ public class PlayerCombat : MonoBehaviour
 
         // execute attack
         stats.isAttacking = true;
-        Collider[] hitColliders = Physics.OverlapBox(attackPoint.position, attackRange, Quaternion.identity, enemyLayers);
-        attackIndicator.SetActive(true);
+        attackObject.SetActive(true);
+
+        //needs to be scale / 2 to be like radius on both sides
+        Collider[] hitColliders = Physics.OverlapBox(attackObject.transform.position, attackObject.transform.lossyScale/2, Quaternion.identity, enemyLayers);
         foreach(Collider enemy in hitColliders) {
             //might want to make an Enemy file for this
             var enemyAI = enemy.GetComponent<BaseEnemyAI>();
@@ -113,11 +113,10 @@ public class PlayerCombat : MonoBehaviour
                 enemyAI.Die();
             }
         }
-
         //delay next attack
         _playerAudio.PlayUpSound();
         nextUpAttackTime = Time.time + upCooldown;
-        StartCoroutine(HideCube(0.25f));
+        StartCoroutine(HideCube(0.1f));
     }
 
     private void PerformDownAttack() {
@@ -197,16 +196,17 @@ public class PlayerCombat : MonoBehaviour
     }
 
     void OnDrawGizmosSelected() {
-        if (attackPoint == null) {
+        if (attackObject == null) {
             return;
         }
         Gizmos.color = Color.red;
-        Gizmos.DrawWireCube(attackPoint.position, attackRange);
+        //this one needs to be not /2 since it doesnt double on both sides
+        Gizmos.DrawWireCube(attackObject.transform.position, attackObject.transform.lossyScale);
     }
 
     IEnumerator HideCube(float time) {
         yield return new WaitForSeconds(time);
-        attackIndicator.SetActive(false);
+        attackObject.SetActive(false);
         stats.isAttacking = false;
     }
 


### PR DESCRIPTION
Removed attack point and the attack range vector from player combat for up attack
Instead, it takes the position of the attackobject (formerly cube) child of player bot, and lossy scale/2 width.
The reason I'm taking half the lossy scale is i think it counts as like a radius after testing it. That is, when i tried lossyscale, i would kill enemies out of the hitbox. Having said that, lossyscale/2 sometimes seems unforgiving, so maybe we can just make the range bigger

Also now the cube can be moved wherever and the attack range should follow (e.g. move it more forward of the player).
